### PR TITLE
[FIX]fix error delete user id by unionid url

### DIFF
--- a/common/djangoapps/util/dintalkcompany.py
+++ b/common/djangoapps/util/dintalkcompany.py
@@ -26,6 +26,7 @@ ACCESS_TOKEN_URL = 'https://oapi.dingtalk.com/gettoken'
 USER_DEPARTMENT_LISTIDS_URL = 'https://oapi.dingtalk.com/department/list_ids'
 USER_LIST_IDS_LIST_URL = 'https://oapi.dingtalk.com/user/getDeptMember'
 USER_DETAIL_URL = 'https://oapi.dingtalk.com/user/get'
+USER_ID_BY_UNIONID_URL = 'https://oapi.dingtalk.com/user/getUseridByUnionid'
 
 error_msg_no_email_info = _('No email information')
 error_msg_user_existed_in_database = _('User existed in databases')


### PR DESCRIPTION
之前修改代码逻辑 误删了USER_ID_BY_UNIONID_URL  可能导致去除离职人员的功能无法正常使用 